### PR TITLE
[STEP-9] 필터 및 인터셉터 추가 + 응답 객체 리팩토링

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/api/coupon/UserCouponApi.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/coupon/UserCouponApi.kt
@@ -28,6 +28,8 @@ interface UserCouponApi {
     fun findAll(
         @Parameter(description = "조회할 유저 ID", required = true)
         userId: Long,
+        @Parameter(description = "인증된 유저 ID", required = true)
+        authenticationId: Long,
         @ParameterObject
         pageable: Pageable,
     ): ResponseEntity<CustomResponse<CouponsResponse>>
@@ -60,6 +62,8 @@ interface UserCouponApi {
     fun issue(
         @Parameter(description = "조회할 유저 ID", required = true)
         userId: Long,
+        @Parameter(description = "인증된 유저 ID", required = true)
+        authenticationId: Long,
         @RequestBody(description = "쿠폰 발급 요청 정보", required = true)
         request: IssueCouponRequest,
     ): ResponseEntity<CustomResponse<Unit>>

--- a/src/main/kotlin/kr/hhplus/be/server/api/coupon/UserCouponController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/coupon/UserCouponController.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.api.coupon
 
 import kr.hhplus.be.server.api.coupon.request.IssueCouponRequest
 import kr.hhplus.be.server.api.coupon.response.CouponsResponse
+import kr.hhplus.be.server.api.coupon.response.toResponse
 import kr.hhplus.be.server.application.coupon.CouponUseCase
 import kr.hhplus.be.server.application.coupon.command.FindUserCouponCommand
 import kr.hhplus.be.server.common.constant.SuccessCode
@@ -23,6 +24,7 @@ class UserCouponController(
     ): ResponseEntity<CustomResponse<CouponsResponse>> =
         FindUserCouponCommand(userId, pageable)
             .let { couponUseCase.findAllByUserId(it) }
+            .toResponse()
             .let { CustomResponse.success(SuccessCode.COUPON_LIST_QUERY, it) }
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 

--- a/src/main/kotlin/kr/hhplus/be/server/api/coupon/UserCouponController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/coupon/UserCouponController.kt
@@ -5,6 +5,7 @@ import kr.hhplus.be.server.api.coupon.response.CouponsResponse
 import kr.hhplus.be.server.api.coupon.response.toResponse
 import kr.hhplus.be.server.application.coupon.CouponUseCase
 import kr.hhplus.be.server.application.coupon.command.FindUserCouponCommand
+import kr.hhplus.be.server.common.constant.AuthConstants
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.common.model.CustomResponse
 import org.springframework.data.domain.Pageable
@@ -20,9 +21,11 @@ class UserCouponController(
     @GetMapping
     override fun findAll(
         @PathVariable userId: Long,
+        @RequestAttribute(AuthConstants.AUTH_ID) authenticationId: Long,
         pageable: Pageable,
     ): ResponseEntity<CustomResponse<CouponsResponse>> =
-        FindUserCouponCommand(userId, pageable)
+        FindUserCouponCommand
+            .of(userId, authenticationId, pageable)
             .let { couponUseCase.findAllByUserId(it) }
             .toResponse()
             .let { CustomResponse.success(SuccessCode.COUPON_LIST_QUERY, it) }
@@ -31,10 +34,11 @@ class UserCouponController(
     @PostMapping
     override fun issue(
         @PathVariable userId: Long,
+        @RequestAttribute(AuthConstants.AUTH_ID) authenticationId: Long,
         @RequestBody request: IssueCouponRequest,
     ): ResponseEntity<CustomResponse<Unit>> =
         request
-            .toCommand(userId)
+            .toCommand(userId, authenticationId)
             .let { couponUseCase.issue(it) }
             .let { CustomResponse.success(SuccessCode.COUPON_ISSUE_SUCCESS, it) }
             .let { ResponseEntity.status(HttpStatus.CREATED).body(it) }

--- a/src/main/kotlin/kr/hhplus/be/server/api/coupon/request/IssueCouponRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/coupon/request/IssueCouponRequest.kt
@@ -1,13 +1,21 @@
 package kr.hhplus.be.server.api.coupon.request
 
 import kr.hhplus.be.server.application.coupon.command.IssueCouponCommand
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
 
 data class IssueCouponRequest(
     val couponPolicyId: Long,
 ) {
-    fun toCommand(userId: Long) =
-        IssueCouponCommand(
+    fun toCommand(
+        userId: Long,
+        authenticationId: Long,
+    ): IssueCouponCommand {
+        if (userId != authenticationId) throw BusinessException(ErrorCode.FORBIDDEN)
+
+        return IssueCouponCommand(
             userId = userId,
             couponPolicyId = couponPolicyId,
         )
+    }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/coupon/response/CouponResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/coupon/response/CouponResponse.kt
@@ -1,5 +1,7 @@
 package kr.hhplus.be.server.api.coupon.response
 
+import kr.hhplus.be.server.application.coupon.info.CouponInfo
+import kr.hhplus.be.server.application.coupon.info.CouponsInfo
 import kr.hhplus.be.server.domain.coupon.CouponDiscountType
 import kr.hhplus.be.server.domain.coupon.CouponStatus
 
@@ -17,3 +19,20 @@ data class CouponsResponse(
     val coupons: List<CouponResponse>,
     val hasNext: Boolean,
 )
+
+fun CouponInfo.toResponse() =
+    CouponResponse(
+        id = id,
+        policyId = policyId,
+        name = name,
+        description = description,
+        discountType = discountType,
+        discountValue = discountValue,
+        status = status,
+    )
+
+fun CouponsInfo.toResponse() =
+    CouponsResponse(
+        coupons = coupons.map { it.toResponse() },
+        hasNext = hasNext,
+    )

--- a/src/main/kotlin/kr/hhplus/be/server/api/order/OrderApi.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/order/OrderApi.kt
@@ -38,5 +38,6 @@ interface OrderApi {
     fun order(
         @RequestBody(description = "주문 요청 정보", required = true)
         request: OrderRequest,
+        authenticationId: Long,
     ): ResponseEntity<CustomResponse<OrderResponse>>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/order/OrderController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/order/OrderController.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.api.order
 
 import kr.hhplus.be.server.api.order.request.OrderRequest
 import kr.hhplus.be.server.api.order.response.OrderResponse
+import kr.hhplus.be.server.api.order.response.toResponse
 import kr.hhplus.be.server.application.order.OrderUseCase
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.common.model.CustomResponse
@@ -24,6 +25,7 @@ class OrderController(
         request
             .toCommand()
             .let { orderUseCase.order(it) }
+            .toResponse()
             .let { CustomResponse.success(SuccessCode.ORDER_CREATED, it) }
             .let { ResponseEntity.status(HttpStatus.CREATED).body(it) }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/order/OrderController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/order/OrderController.kt
@@ -4,14 +4,12 @@ import kr.hhplus.be.server.api.order.request.OrderRequest
 import kr.hhplus.be.server.api.order.response.OrderResponse
 import kr.hhplus.be.server.api.order.response.toResponse
 import kr.hhplus.be.server.application.order.OrderUseCase
+import kr.hhplus.be.server.common.constant.AuthConstants
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.common.model.CustomResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/orders")
@@ -21,9 +19,10 @@ class OrderController(
     @PostMapping
     override fun order(
         @RequestBody request: OrderRequest,
+        @RequestAttribute(AuthConstants.AUTH_ID) authenticationId: Long,
     ): ResponseEntity<CustomResponse<OrderResponse>> =
         request
-            .toCommand()
+            .toCommand(authenticationId)
             .let { orderUseCase.order(it) }
             .toResponse()
             .let { CustomResponse.success(SuccessCode.ORDER_CREATED, it) }

--- a/src/main/kotlin/kr/hhplus/be/server/api/order/request/OrderRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/order/request/OrderRequest.kt
@@ -2,18 +2,23 @@ package kr.hhplus.be.server.api.order.request
 
 import kr.hhplus.be.server.application.order.command.OrderCommand
 import kr.hhplus.be.server.application.order.command.OrderItemCommand
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
 
 data class OrderRequest(
     val userId: Long,
     val items: List<OrderItemRequest>,
     val couponId: Long?,
 ) {
-    fun toCommand() =
-        OrderCommand(
+    fun toCommand(authenticationId: Long): OrderCommand {
+        if (userId != authenticationId) throw BusinessException(ErrorCode.FORBIDDEN)
+
+        return OrderCommand(
             userId = userId,
             items = items.map { it.toCommand() },
             couponId = couponId,
         )
+    }
 }
 
 data class OrderItemRequest(

--- a/src/main/kotlin/kr/hhplus/be/server/api/order/response/OrderResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/order/response/OrderResponse.kt
@@ -1,12 +1,12 @@
 package kr.hhplus.be.server.api.order.response
 
-import kr.hhplus.be.server.domain.order.Order
+import kr.hhplus.be.server.application.order.info.OrderInfo
 
 data class OrderResponse(
     val orderId: Long,
 )
 
-fun Order.toResponse() =
+fun OrderInfo.toResponse() =
     OrderResponse(
-        orderId = id,
+        orderId = orderId,
     )

--- a/src/main/kotlin/kr/hhplus/be/server/api/payment/PaymentApi.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/payment/PaymentApi.kt
@@ -38,5 +38,6 @@ interface PaymentApi {
     fun pay(
         @RequestBody(description = "결제 요청 정보", required = true)
         request: PaymentRequest,
+        authenticationId: Long,
     ): ResponseEntity<CustomResponse<Unit>>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/payment/PaymentController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/payment/PaymentController.kt
@@ -2,13 +2,11 @@ package kr.hhplus.be.server.api.payment
 
 import kr.hhplus.be.server.api.payment.request.PaymentRequest
 import kr.hhplus.be.server.application.payment.PaymentUseCase
+import kr.hhplus.be.server.common.constant.AuthConstants
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.common.model.CustomResponse
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/payments")
@@ -18,9 +16,10 @@ class PaymentController(
     @PostMapping
     override fun pay(
         @RequestBody request: PaymentRequest,
+        @RequestAttribute(AuthConstants.AUTH_ID) authenticationId: Long,
     ): ResponseEntity<CustomResponse<Unit>> =
         request
-            .toCommand()
+            .toCommand(authenticationId)
             .let { paymentUseCase.pay(it) }
             .let { CustomResponse.success(SuccessCode.PAYMENT_COMPLETED) }
             .let { ResponseEntity.ok(it) }

--- a/src/main/kotlin/kr/hhplus/be/server/api/payment/request/PaymentRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/payment/request/PaymentRequest.kt
@@ -1,14 +1,18 @@
 package kr.hhplus.be.server.api.payment.request
 
 import kr.hhplus.be.server.application.payment.command.PaymentCommand
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
 
 data class PaymentRequest(
     val userId: Long,
     val orderId: Long,
 ) {
-    fun toCommand() =
-        PaymentCommand(
+    fun toCommand(authenticationId: Long): PaymentCommand {
+        if (userId != authenticationId) throw BusinessException(ErrorCode.FORBIDDEN)
+        return PaymentCommand(
             userId = userId,
             orderId = orderId,
         )
+    }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/product/ProductApi.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/product/ProductApi.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import kr.hhplus.be.server.api.product.response.PopularProductsResponse
 import kr.hhplus.be.server.api.product.response.ProductsResponse
+import kr.hhplus.be.server.application.product.info.PopularProductsInfo
+import kr.hhplus.be.server.application.product.info.ProductsInfo
 import kr.hhplus.be.server.common.model.CustomResponse
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/kr/hhplus/be/server/api/product/ProductController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/product/ProductController.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.api.product
 
 import kr.hhplus.be.server.api.product.response.PopularProductsResponse
 import kr.hhplus.be.server.api.product.response.ProductsResponse
+import kr.hhplus.be.server.api.product.response.toResponse
 import kr.hhplus.be.server.application.product.ProductUseCase
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.common.model.CustomResponse
@@ -21,6 +22,7 @@ class ProductController(
     override fun findAll(pageable: Pageable): ResponseEntity<CustomResponse<ProductsResponse>> =
         productUseCase
             .findAll(pageable)
+            .toResponse()
             .let { CustomResponse.success(SuccessCode.PRODUCT_QUERY, it) }
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 
@@ -28,6 +30,7 @@ class ProductController(
     override fun findPopularProducts(): ResponseEntity<CustomResponse<PopularProductsResponse>> =
         productUseCase
             .findPopularProducts()
+            .toResponse()
             .let { CustomResponse.success(SuccessCode.POPULAR_PRODUCT_QUERY, it) }
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/product/response/PopularProductResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/product/response/PopularProductResponse.kt
@@ -1,5 +1,8 @@
 package kr.hhplus.be.server.api.product.response
 
+import kr.hhplus.be.server.application.product.info.PopularProductInfo
+import kr.hhplus.be.server.application.product.info.PopularProductsInfo
+
 data class PopularProductResponse(
     val id: Long,
     val name: String,
@@ -10,3 +13,16 @@ data class PopularProductResponse(
 data class PopularProductsResponse(
     val products: List<PopularProductResponse>,
 )
+
+fun PopularProductInfo.toResponse() =
+    PopularProductResponse(
+        id = id,
+        name = name,
+        price = price,
+        totalSales = totalSales,
+    )
+
+fun PopularProductsInfo.toResponse() =
+    PopularProductsResponse(
+        products = products.map { it.toResponse() },
+    )

--- a/src/main/kotlin/kr/hhplus/be/server/api/product/response/ProductResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/product/response/ProductResponse.kt
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.api.product.response
 
-import kr.hhplus.be.server.domain.product.Product
+import kr.hhplus.be.server.application.product.info.ProductInfo
+import kr.hhplus.be.server.application.product.info.ProductsInfo
 
 data class ProductResponse(
     val id: Long,
@@ -14,10 +15,16 @@ data class ProductsResponse(
     val hasNext: Boolean,
 )
 
-fun Product.toResponse() =
+fun ProductInfo.toResponse() =
     ProductResponse(
         id = id,
         name = name,
         price = price,
         stock = stock,
+    )
+
+fun ProductsInfo.toResponse() =
+    ProductsResponse(
+        products = products.map { it.toResponse() },
+        hasNext = hasNext,
     )

--- a/src/main/kotlin/kr/hhplus/be/server/api/user/UserBalanceApi.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/user/UserBalanceApi.kt
@@ -38,6 +38,8 @@ interface UserBalanceApi {
         @Parameter(description = "충전할 유저 ID", required = true)
         @PathVariable
         userId: Long,
+        @Parameter(description = "인증된 유저 ID", required = true)
+        authenticationId: Long,
         @RequestBody(description = "잔액 충전 요청 정보", required = true)
         request: UserBalanceRequest,
     ): ResponseEntity<CustomResponse<UserBalanceResponse>>
@@ -60,5 +62,7 @@ interface UserBalanceApi {
         @Parameter(description = "조회할 유저 ID", required = true)
         @PathVariable
         userId: Long,
+        @Parameter(description = "인증된 유저 ID", required = true)
+        authenticationId: Long,
     ): ResponseEntity<CustomResponse<UserBalanceResponse>>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/user/UserBalanceController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/user/UserBalanceController.kt
@@ -2,10 +2,9 @@ package kr.hhplus.be.server.api.user
 
 import kr.hhplus.be.server.api.user.request.UserBalanceRequest
 import kr.hhplus.be.server.api.user.response.UserBalanceResponse
+import kr.hhplus.be.server.api.user.response.toResponse
 import kr.hhplus.be.server.application.user.UserBalanceUseCase
-import kr.hhplus.be.server.common.constant.ErrorCode
 import kr.hhplus.be.server.common.constant.SuccessCode
-import kr.hhplus.be.server.common.exception.BusinessException
 import kr.hhplus.be.server.common.model.CustomResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -24,6 +23,7 @@ class UserBalanceController(
         request
             .toCommand(userId)
             .let { userBalanceUseCase.chargeBalance(it) }
+            .toResponse()
             .let { CustomResponse.success(SuccessCode.USER_BALANCE_CHARGE, it) }
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 
@@ -33,6 +33,7 @@ class UserBalanceController(
     ): ResponseEntity<CustomResponse<UserBalanceResponse>> =
         userBalanceUseCase
             .getBalance(userId)
+            .toResponse()
             .let { CustomResponse.success(SuccessCode.USER_BALANCE_QUERY, it) }
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/user/UserBalanceController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/user/UserBalanceController.kt
@@ -4,6 +4,8 @@ import kr.hhplus.be.server.api.user.request.UserBalanceRequest
 import kr.hhplus.be.server.api.user.response.UserBalanceResponse
 import kr.hhplus.be.server.api.user.response.toResponse
 import kr.hhplus.be.server.application.user.UserBalanceUseCase
+import kr.hhplus.be.server.application.user.command.GetBalanceCommand
+import kr.hhplus.be.server.common.constant.AuthConstants
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.common.model.CustomResponse
 import org.springframework.http.HttpStatus
@@ -18,10 +20,11 @@ class UserBalanceController(
     @PatchMapping
     override fun charge(
         @PathVariable userId: Long,
+        @RequestAttribute(AuthConstants.AUTH_ID) authenticationId: Long,
         @RequestBody request: UserBalanceRequest,
     ): ResponseEntity<CustomResponse<UserBalanceResponse>> =
         request
-            .toCommand(userId)
+            .toCommand(userId, authenticationId)
             .let { userBalanceUseCase.chargeBalance(it) }
             .toResponse()
             .let { CustomResponse.success(SuccessCode.USER_BALANCE_CHARGE, it) }
@@ -30,9 +33,11 @@ class UserBalanceController(
     @GetMapping
     override fun get(
         @PathVariable userId: Long,
+        @RequestAttribute(AuthConstants.AUTH_ID) authenticationId: Long,
     ): ResponseEntity<CustomResponse<UserBalanceResponse>> =
-        userBalanceUseCase
-            .getBalance(userId)
+        GetBalanceCommand
+            .of(userId, authenticationId)
+            .let { userBalanceUseCase.getBalance(it) }
             .toResponse()
             .let { CustomResponse.success(SuccessCode.USER_BALANCE_QUERY, it) }
             .let { ResponseEntity.status(HttpStatus.OK).body(it) }

--- a/src/main/kotlin/kr/hhplus/be/server/api/user/request/UserBalanceRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/user/request/UserBalanceRequest.kt
@@ -13,9 +13,15 @@ data class UserBalanceRequest(
         }
     }
 
-    fun toCommand(userId: Long) =
-        ChargeBalanceCommand(
+    fun toCommand(
+        userId: Long,
+        authenticationId: Long,
+    ): ChargeBalanceCommand {
+        if (userId != authenticationId) throw BusinessException(ErrorCode.FORBIDDEN)
+
+        return ChargeBalanceCommand(
             userId = userId,
             amount = amount!!,
         )
+    }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/api/user/response/UserBalanceResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/api/user/response/UserBalanceResponse.kt
@@ -1,12 +1,12 @@
 package kr.hhplus.be.server.api.user.response
 
-import kr.hhplus.be.server.domain.user.User
+import kr.hhplus.be.server.application.user.info.UserBalanceInfo
 
 data class UserBalanceResponse(
     val amount: Long,
 )
 
-fun User.toBalanceResponse() =
+fun UserBalanceInfo.toResponse() =
     UserBalanceResponse(
-        amount = this.balance,
+        amount = this.amount,
     )

--- a/src/main/kotlin/kr/hhplus/be/server/application/coupon/CouponUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/coupon/CouponUseCase.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.application.coupon
 
-import kr.hhplus.be.server.api.coupon.response.CouponsResponse
+import kr.hhplus.be.server.application.coupon.info.CouponsInfo
 import kr.hhplus.be.server.application.coupon.command.FindUserCouponCommand
 import kr.hhplus.be.server.application.coupon.command.IssueCouponCommand
 import kr.hhplus.be.server.domain.coupon.CouponService
@@ -17,11 +17,11 @@ class CouponUseCase(
         couponService.issue(user, command.couponPolicyId)
     }
 
-    fun findAllByUserId(command: FindUserCouponCommand): CouponsResponse {
+    fun findAllByUserId(command: FindUserCouponCommand): CouponsInfo {
         userService.getById(command.userId)
 
         return couponService
             .findAllByUserId(command)
-            .let { CouponsResponse(it.content, it.hasNext()) }
+            .let { CouponsInfo(it.content, it.hasNext()) }
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/application/coupon/CouponUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/coupon/CouponUseCase.kt
@@ -1,8 +1,8 @@
 package kr.hhplus.be.server.application.coupon
 
-import kr.hhplus.be.server.application.coupon.info.CouponsInfo
 import kr.hhplus.be.server.application.coupon.command.FindUserCouponCommand
 import kr.hhplus.be.server.application.coupon.command.IssueCouponCommand
+import kr.hhplus.be.server.application.coupon.info.CouponsInfo
 import kr.hhplus.be.server.domain.coupon.CouponService
 import kr.hhplus.be.server.domain.user.UserService
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/kr/hhplus/be/server/application/coupon/info/CouponInfo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/coupon/info/CouponInfo.kt
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.application.coupon.info
+
+import kr.hhplus.be.server.domain.coupon.CouponDiscountType
+import kr.hhplus.be.server.domain.coupon.CouponStatus
+
+data class CouponInfo(
+    val id: Long,
+    val policyId: Long,
+    val name: String,
+    val description: String,
+    val discountType: CouponDiscountType,
+    val discountValue: Long,
+    val status: CouponStatus,
+)
+
+data class CouponsInfo(
+    val coupons: List<CouponInfo>,
+    val hasNext: Boolean,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/application/order/OrderUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/order/OrderUseCase.kt
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.application.order
 
-import kr.hhplus.be.server.api.order.response.OrderResponse
-import kr.hhplus.be.server.api.order.response.toResponse
+import kr.hhplus.be.server.application.order.info.OrderInfo
+import kr.hhplus.be.server.application.order.info.toResponse
 import kr.hhplus.be.server.application.order.command.OrderCommand
 import kr.hhplus.be.server.application.product.info.getTotalPrice
 import kr.hhplus.be.server.domain.coupon.CouponService
@@ -21,7 +21,7 @@ class OrderUseCase(
     private val discountService: DiscountService,
 ) {
     @Transactional
-    fun order(command: OrderCommand): OrderResponse {
+    fun order(command: OrderCommand): OrderInfo {
         val user = userService.getById(command.userId)
         val products = productService.findOrderableProductByIds(command.items)
 

--- a/src/main/kotlin/kr/hhplus/be/server/application/order/info/OrderInfo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/order/info/OrderInfo.kt
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.application.order.info
+
+import kr.hhplus.be.server.domain.order.Order
+
+data class OrderInfo(
+    val orderId: Long,
+)
+
+fun Order.toResponse() =
+    OrderInfo(
+        orderId = id,
+    )

--- a/src/main/kotlin/kr/hhplus/be/server/application/payment/PaymentUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/payment/PaymentUseCase.kt
@@ -4,7 +4,6 @@ import kr.hhplus.be.server.application.order.command.toCommand
 import kr.hhplus.be.server.application.payment.command.PaymentCommand
 import kr.hhplus.be.server.application.user.command.toUseBalanceCommand
 import kr.hhplus.be.server.domain.coupon.CouponService
-import kr.hhplus.be.server.domain.discount.DiscountService
 import kr.hhplus.be.server.domain.order.OrderService
 import kr.hhplus.be.server.domain.payment.PaymentService
 import kr.hhplus.be.server.domain.product.ProductService
@@ -23,6 +22,7 @@ class PaymentUseCase(
     @Transactional
     fun pay(command: PaymentCommand) {
         val user = userService.getById(command.userId)
+
         val order =
             orderService
                 .getByIdAndUserIdWithLock(command.orderId, user.id)

--- a/src/main/kotlin/kr/hhplus/be/server/application/product/ProductUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/product/ProductUseCase.kt
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.application.product
 
-import kr.hhplus.be.server.api.product.response.PopularProductsResponse
-import kr.hhplus.be.server.api.product.response.ProductsResponse
+import kr.hhplus.be.server.application.product.info.PopularProductsInfo
+import kr.hhplus.be.server.application.product.info.ProductsInfo
 import kr.hhplus.be.server.domain.product.ProductService
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
@@ -13,10 +13,10 @@ class ProductUseCase(
     fun findAll(pageable: Pageable) =
         productService
             .findAll(pageable)
-            .let { ProductsResponse(it.content, it.hasNext()) }
+            .let { ProductsInfo(it.content, it.hasNext()) }
 
     fun findPopularProducts() =
         productService
             .findPopularProducts()
-            .let { PopularProductsResponse(it) }
+            .let { PopularProductsInfo(it) }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/application/product/info/PopularProductInfo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/product/info/PopularProductInfo.kt
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.application.product.info
+
+data class PopularProductInfo(
+    val id: Long,
+    val name: String,
+    val price: Long,
+    val totalSales: Long,
+)
+
+data class PopularProductsInfo(
+    val products: List<PopularProductInfo>,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/application/product/info/ProductInfo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/product/info/ProductInfo.kt
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.application.product.info
+
+import kr.hhplus.be.server.domain.product.Product
+
+data class ProductInfo(
+    val id: Long,
+    val name: String,
+    val price: Long,
+    val stock: Int,
+)
+
+data class ProductsInfo(
+    val products: List<ProductInfo>,
+    val hasNext: Boolean,
+)
+
+fun Product.toInfo() =
+    ProductInfo(
+        id = id,
+        name = name,
+        price = price,
+        stock = stock,
+    )

--- a/src/main/kotlin/kr/hhplus/be/server/application/user/UserBalanceUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/user/UserBalanceUseCase.kt
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.application.user
 
-import kr.hhplus.be.server.api.user.response.UserBalanceResponse
-import kr.hhplus.be.server.api.user.response.toBalanceResponse
+import kr.hhplus.be.server.application.user.info.UserBalanceInfo
+import kr.hhplus.be.server.application.user.info.toBalanceResult
 import kr.hhplus.be.server.application.user.command.ChargeBalanceCommand
 import kr.hhplus.be.server.domain.user.UserService
 import org.springframework.stereotype.Component
@@ -14,8 +14,8 @@ class UserBalanceUseCase(
         userService
             .chargeBalance(command)
 
-    fun getBalance(userId: Long): UserBalanceResponse =
+    fun getBalance(userId: Long): UserBalanceInfo =
         userService
             .getById(userId)
-            .toBalanceResponse()
+            .toBalanceResult()
 }

--- a/src/main/kotlin/kr/hhplus/be/server/application/user/UserBalanceUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/user/UserBalanceUseCase.kt
@@ -1,8 +1,9 @@
 package kr.hhplus.be.server.application.user
 
+import kr.hhplus.be.server.application.user.command.ChargeBalanceCommand
+import kr.hhplus.be.server.application.user.command.GetBalanceCommand
 import kr.hhplus.be.server.application.user.info.UserBalanceInfo
 import kr.hhplus.be.server.application.user.info.toBalanceResult
-import kr.hhplus.be.server.application.user.command.ChargeBalanceCommand
 import kr.hhplus.be.server.domain.user.UserService
 import org.springframework.stereotype.Component
 
@@ -14,8 +15,8 @@ class UserBalanceUseCase(
         userService
             .chargeBalance(command)
 
-    fun getBalance(userId: Long): UserBalanceInfo =
+    fun getBalance(command: GetBalanceCommand): UserBalanceInfo =
         userService
-            .getById(userId)
+            .getById(command.userId)
             .toBalanceResult()
 }

--- a/src/main/kotlin/kr/hhplus/be/server/application/user/command/GetBalanceCommand.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/user/command/GetBalanceCommand.kt
@@ -1,21 +1,20 @@
-package kr.hhplus.be.server.application.coupon.command
+package kr.hhplus.be.server.application.user.command
 
 import kr.hhplus.be.server.common.constant.ErrorCode
 import kr.hhplus.be.server.common.exception.BusinessException
-import org.springframework.data.domain.Pageable
 
-data class FindUserCouponCommand(
+data class GetBalanceCommand(
     val userId: Long,
-    val pageable: Pageable,
 ) {
     companion object {
         fun of(
             userId: Long,
             authenticationId: Long,
-            pageable: Pageable,
-        ): FindUserCouponCommand {
+        ): GetBalanceCommand {
             if (userId != authenticationId) throw BusinessException(ErrorCode.FORBIDDEN)
-            return FindUserCouponCommand(userId, pageable)
+            return GetBalanceCommand(
+                userId = userId,
+            )
         }
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/application/user/info/UserBalanceInfo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/user/info/UserBalanceInfo.kt
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.application.user.info
+
+import kr.hhplus.be.server.domain.user.User
+
+data class UserBalanceInfo(
+    val amount: Long,
+)
+
+fun User.toBalanceResult() =
+    UserBalanceInfo(
+        amount = this.balance,
+    )

--- a/src/main/kotlin/kr/hhplus/be/server/common/config/WebConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/config/WebConfig.kt
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.common.config
+
+import kr.hhplus.be.server.common.interceptor.UserAuthenticationInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    val userAuthenticationInterceptor: UserAuthenticationInterceptor,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry
+            .addInterceptor(userAuthenticationInterceptor)
+            .addPathPatterns("/api/v1/users/**")
+            .addPathPatterns("/api/v1/orders")
+            .addPathPatterns("/api/v1/payments")
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/common/constant/AuthConstants.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/constant/AuthConstants.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.common.constant
+
+object AuthConstants {
+    const val AUTH_ID = "authenticationId"
+}

--- a/src/main/kotlin/kr/hhplus/be/server/common/constant/ErrorCode.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/constant/ErrorCode.kt
@@ -10,6 +10,8 @@ enum class ErrorCode(
     USER_BALANCE_BELOW_MINIMUM(HttpStatus.BAD_REQUEST, "충전 금액은 최소 10,000원 이상이어야 합니다."),
     USER_BALANCE_EXCEEDS_LIMIT(HttpStatus.BAD_REQUEST, "잔액 상한을 초과할 수 없습니다."),
     USER_BALANCE_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "잔액 충전에 실패했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰입니다."),
     COUPON_ISSUE_NOT_STARTED(HttpStatus.BAD_REQUEST, "쿠폰 발급 기간이 아직 시작되지 않았습니다."),
     COUPON_ISSUE_EXPIRED(HttpStatus.BAD_REQUEST, "쿠폰 발급 기간이 지났습니다."),

--- a/src/main/kotlin/kr/hhplus/be/server/common/filter/HttpLoggingFilter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/filter/HttpLoggingFilter.kt
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.common.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+
+@Component
+class HttpLoggingFilter : OncePerRequestFilter() {
+    private val log = LoggerFactory.getLogger(HttpLoggingFilter::class.java)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requestWrapper = ContentCachingRequestWrapper(request)
+        val responseWrapper = ContentCachingResponseWrapper(response)
+        try {
+            filterChain.doFilter(requestWrapper, responseWrapper)
+
+            val method = requestWrapper.method
+            val uri = requestWrapper.requestURI
+            val headers =
+                requestWrapper.headerNames
+                    .toList()
+                    .joinToString { "$it: ${requestWrapper.getHeader(it)}" }
+            val requestBody = String(requestWrapper.contentAsByteArray, Charsets.UTF_8).ifBlank { "No Body" }
+            log.debug("HTTP Request: [Method: $method, URI: $uri, Headers: $headers, Body: $requestBody]")
+
+            val status = responseWrapper.status
+            val responseBody = String(responseWrapper.contentAsByteArray, Charsets.UTF_8).ifBlank { "No Body" }
+            log.debug("HTTP Response: [Status: $status, Body: $responseBody]")
+        } finally {
+            responseWrapper.copyBodyToResponse()
+        }
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/common/interceptor/UserAuthenticationInterceptor.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/interceptor/UserAuthenticationInterceptor.kt
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.common.interceptor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kr.hhplus.be.server.common.constant.AuthConstants
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.model.CustomResponse
+import kr.hhplus.be.server.common.util.isNumeric
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class UserAuthenticationInterceptor(
+    private val objectMapper: ObjectMapper,
+) : HandlerInterceptor {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        val userIdFromHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
+
+        if (userIdFromHeader.isNullOrBlank() || !userIdFromHeader.isNumeric()) {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = Charsets.UTF_8.name()
+
+            val errorResponse = CustomResponse.fail(ErrorCode.UNAUTHORIZED)
+            response.writer.write(objectMapper.writeValueAsString(errorResponse))
+            return false
+        }
+
+        request.setAttribute(AuthConstants.AUTH_ID, userIdFromHeader)
+        return true
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/common/util/StringUtils.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/util/StringUtils.kt
@@ -1,0 +1,3 @@
+package kr.hhplus.be.server.common.util
+
+fun String.isNumeric(): Boolean = this.all { it.isDigit() }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponRepository.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.domain.coupon
 
-import kr.hhplus.be.server.api.coupon.response.CouponResponse
+import kr.hhplus.be.server.application.coupon.info.CouponInfo
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -15,7 +15,7 @@ interface CouponRepository {
     fun findAllByUserId(
         userId: Long,
         pageable: Pageable,
-    ): Slice<CouponResponse>
+    ): Slice<CouponInfo>
 
     fun findById(couponId: Long): Coupon?
 

--- a/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponService.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.domain.coupon
 
-import kr.hhplus.be.server.api.coupon.response.CouponResponse
+import kr.hhplus.be.server.application.coupon.info.CouponInfo
 import kr.hhplus.be.server.application.coupon.command.FindUserCouponCommand
 import kr.hhplus.be.server.common.constant.ErrorCode
 import kr.hhplus.be.server.common.exception.BusinessException
@@ -31,7 +31,7 @@ class CouponService(
         couponRepository.save(coupon)
     }
 
-    fun findAllByUserId(command: FindUserCouponCommand): Slice<CouponResponse> =
+    fun findAllByUserId(command: FindUserCouponCommand): Slice<CouponInfo> =
         couponRepository.findAllByUserId(command.userId, command.pageable)
 
     fun getOrderableCoupon(

--- a/src/main/kotlin/kr/hhplus/be/server/domain/product/ProductRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/product/ProductRepository.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.domain.product
 
-import kr.hhplus.be.server.api.product.response.PopularProductResponse
+import kr.hhplus.be.server.application.product.info.PopularProductInfo
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -13,5 +13,5 @@ interface ProductRepository {
 
     fun saveAll(products: List<Product>): List<Product>
 
-    fun findPopularProducts(): List<PopularProductResponse>
+    fun findPopularProducts(): List<PopularProductInfo>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/product/ProductService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/product/ProductService.kt
@@ -1,8 +1,8 @@
 package kr.hhplus.be.server.domain.product
 
-import kr.hhplus.be.server.api.product.response.PopularProductResponse
-import kr.hhplus.be.server.api.product.response.ProductResponse
-import kr.hhplus.be.server.api.product.response.toResponse
+import kr.hhplus.be.server.application.product.info.PopularProductInfo
+import kr.hhplus.be.server.application.product.info.ProductInfo
+import kr.hhplus.be.server.application.product.info.toInfo
 import kr.hhplus.be.server.application.order.command.OrderItemCommand
 import kr.hhplus.be.server.application.order.command.toSortedProductIds
 import kr.hhplus.be.server.application.product.info.OrderItemInfo
@@ -18,10 +18,10 @@ import org.springframework.transaction.annotation.Transactional
 class ProductService(
     private val productRepository: ProductRepository,
 ) {
-    fun findAll(pageable: Pageable): Slice<ProductResponse> =
+    fun findAll(pageable: Pageable): Slice<ProductInfo> =
         productRepository
             .findAll(pageable)
-            .map { it.toResponse() }
+            .map { it.toInfo() }
 
     fun findOrderableProductByIds(items: List<OrderItemCommand>): List<OrderItemInfo> {
         val productIds = items.map { it.productId }
@@ -52,5 +52,5 @@ class ProductService(
         productRepository.saveAll(products)
     }
 
-    fun findPopularProducts(): List<PopularProductResponse> = productRepository.findPopularProducts()
+    fun findPopularProducts(): List<PopularProductInfo> = productRepository.findPopularProducts()
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/user/UserRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/user/UserRepository.kt
@@ -4,6 +4,4 @@ interface UserRepository {
     fun findById(id: Long): User?
 
     fun save(user: User): User
-
-    fun existsById(id: Long): Boolean
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/user/UserRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/user/UserRepository.kt
@@ -4,4 +4,6 @@ interface UserRepository {
     fun findById(id: Long): User?
 
     fun save(user: User): User
+
+    fun existsById(id: Long): Boolean
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/user/UserService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/user/UserService.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.domain.user
 
-import kr.hhplus.be.server.api.user.response.UserBalanceResponse
+import kr.hhplus.be.server.application.user.info.UserBalanceInfo
 import kr.hhplus.be.server.application.user.command.ChargeBalanceCommand
 import kr.hhplus.be.server.application.user.command.UseBalanceCommand
 import kr.hhplus.be.server.common.constant.ErrorCode
@@ -20,7 +20,7 @@ class UserService(
             ?: throw BusinessException(ErrorCode.USER_NOT_FOUND)
 
     @Transactional
-    fun chargeBalance(command: ChargeBalanceCommand): UserBalanceResponse {
+    fun chargeBalance(command: ChargeBalanceCommand): UserBalanceInfo {
         val chargeBalanceUser =
             getById(command.userId)
                 .apply { this.charge(command.amount) }
@@ -36,7 +36,7 @@ class UserService(
             .createByCharge(savedUser, command.amount)
             .also { balanceHistoryRepository.save(it) }
 
-        return UserBalanceResponse(savedUser.balance)
+        return UserBalanceInfo(savedUser.balance)
     }
 
     @Transactional

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/CouponRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/CouponRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.infrastructure.persistence.coupon
 
-import kr.hhplus.be.server.api.coupon.response.CouponResponse
+import kr.hhplus.be.server.application.coupon.info.CouponInfo
 import kr.hhplus.be.server.domain.coupon.Coupon
 import kr.hhplus.be.server.domain.coupon.CouponRepository
 import org.springframework.data.domain.Pageable
@@ -22,7 +22,7 @@ class CouponRepositoryImpl(
     override fun findAllByUserId(
         userId: Long,
         pageable: Pageable,
-    ): Slice<CouponResponse> = jpaCouponRepository.findAllByUserId(userId, pageable)
+    ): Slice<CouponInfo> = jpaCouponRepository.findAllByUserId(userId, pageable)
 
     override fun findById(couponId: Long): Coupon? = jpaCouponRepository.findByIdOrNull(couponId)
 

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/JpaCouponRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/JpaCouponRepository.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.infrastructure.persistence.coupon
 
-import kr.hhplus.be.server.api.coupon.response.CouponResponse
+import kr.hhplus.be.server.application.coupon.info.CouponInfo
 import kr.hhplus.be.server.domain.coupon.Coupon
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query
 interface JpaCouponRepository : JpaRepository<Coupon, Long> {
     @Query(
         """
-        SELECT new kr.hhplus.be.server.api.coupon.response.CouponResponse(
+        SELECT new kr.hhplus.be.server.application.coupon.info.CouponInfo(
             c.id,
             c.policy.id,
             p.name,
@@ -27,7 +27,7 @@ interface JpaCouponRepository : JpaRepository<Coupon, Long> {
     fun findAllByUserId(
         userId: Long,
         pageable: Pageable,
-    ): Slice<CouponResponse>
+    ): Slice<CouponInfo>
 
     fun findByUserIdAndPolicyId(
         userId: Long,

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/product/DataJpaProductRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/product/DataJpaProductRepository.kt
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.infrastructure.persistence.product
 
 import jakarta.persistence.LockModeType
-import kr.hhplus.be.server.api.product.response.PopularProductResponse
+import kr.hhplus.be.server.application.product.info.PopularProductInfo
 import kr.hhplus.be.server.domain.product.Product
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
@@ -20,7 +20,7 @@ interface DataJpaProductRepository : JpaRepository<Product, Long> {
 
     @Query(
         """
-    SELECT new kr.hhplus.be.server.api.product.response.PopularProductResponse(
+    SELECT new kr.hhplus.be.server.application.product.info.PopularProductInfo(
         p.id,
         p.name, 
         p.price,
@@ -35,5 +35,5 @@ interface DataJpaProductRepository : JpaRepository<Product, Long> {
     LIMIT 5
     """,
     )
-    fun findPopularProducts(): List<PopularProductResponse>
+    fun findPopularProducts(): List<PopularProductInfo>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/product/JpaProductRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/product/JpaProductRepository.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.infrastructure.persistence.product
 
-import kr.hhplus.be.server.api.product.response.PopularProductResponse
+import kr.hhplus.be.server.application.product.info.PopularProductInfo
 import kr.hhplus.be.server.domain.product.Product
 import kr.hhplus.be.server.domain.product.ProductRepository
 import org.springframework.data.domain.Pageable
@@ -19,5 +19,5 @@ class JpaProductRepository(
 
     override fun saveAll(products: List<Product>): List<Product> = dataJpaProductRepository.saveAll(products)
 
-    override fun findPopularProducts(): List<PopularProductResponse> = dataJpaProductRepository.findPopularProducts()
+    override fun findPopularProducts(): List<PopularProductInfo> = dataJpaProductRepository.findPopularProducts()
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/user/JpaUserRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/user/JpaUserRepository.kt
@@ -12,4 +12,6 @@ class JpaUserRepository(
     override fun findById(id: Long): User? = dataJpaUserRepository.findByIdOrNull(id)
 
     override fun save(user: User): User = dataJpaUserRepository.saveAndFlush(user)
+
+    override fun existsById(id: Long): Boolean = dataJpaUserRepository.existsById(id)
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/user/JpaUserRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/user/JpaUserRepository.kt
@@ -13,5 +13,4 @@ class JpaUserRepository(
 
     override fun save(user: User): User = dataJpaUserRepository.saveAndFlush(user)
 
-    override fun existsById(id: Long): Boolean = dataJpaUserRepository.existsById(id)
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@ spring:
 logging:
   level:
     org.hibernate.orm.jdbc.bind: trace
+    kr.hhplus.be.server.common.filter: debug
 ---
 spring.config.activate.on-profile: test
 

--- a/src/test/kotlin/kr/hhplus/be/server/api/coupon/UserCouponControllerTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/coupon/UserCouponControllerTest.kt
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.api.coupon
 
 import kr.hhplus.be.server.api.coupon.request.IssueCouponRequest
-import kr.hhplus.be.server.api.coupon.response.CouponResponse
+import kr.hhplus.be.server.application.coupon.info.CouponInfo
 import kr.hhplus.be.server.common.constant.ErrorCode
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.helper.ConcurrentTestHelper
@@ -229,7 +229,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.code").value(SuccessCode.COUPON_LIST_QUERY.status.value()))
                 .andExpect(jsonPath("$.message").value(SuccessCode.COUPON_LIST_QUERY.message))
-                .andExpect(jsonPath("$.data.coupons", Matchers.hasSize<CouponResponse>(1)))
+                .andExpect(jsonPath("$.data.coupons", Matchers.hasSize<CouponInfo>(1)))
                 .andExpect(jsonPath("$.data.hasNext").value(false))
         }
 

--- a/src/test/kotlin/kr/hhplus/be/server/api/coupon/UserCouponControllerTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/coupon/UserCouponControllerTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -65,6 +66,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.code").value(SuccessCode.COUPON_ISSUE_SUCCESS.status.value()))
@@ -78,6 +80,39 @@ class UserCouponControllerTest : IntegrationTest() {
         }
 
         @Test
+        @DisplayName("[실패] 인증 헤더의 사용자 ID가 유효하지 않으면 401 반환")
+        fun test_fail_when_invalid_user_id() {
+            val userId = 1L
+            val request = IssueCouponRequest(1L)
+
+            mockMvc
+                .perform(
+                    post("/api/v1/users/{userId}/coupons", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.status.value()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.message))
+        }
+
+        @Test
+        @DisplayName("[실패] 인증 아이디와 사용자 아이디가 다르면 403 반환")
+        fun test_fail_when_user_id_and_auth_id_diff() {
+            val userId = 1L
+            val request = IssueCouponRequest(1L)
+
+            mockMvc
+                .perform(
+                    post("/api/v1/users/{userId}/coupons", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, 2L)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isForbidden)
+                .andExpect(jsonPath("$.code").value(ErrorCode.FORBIDDEN.status.value()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN.message))
+        }
+
+        @Test
         @DisplayName("[실패] 존재하지 않는 사용자인 경우 404 반환")
         fun test_fail_when_user_not_found() {
             val userId = 0L
@@ -87,6 +122,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.status.value()))
@@ -103,6 +139,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.code").value(ErrorCode.COUPON_NOT_FOUND.status.value()))
@@ -120,6 +157,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.code").value(ErrorCode.COUPON_OUT_OF_COUNT.status.value()))
@@ -137,6 +175,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.code").value(ErrorCode.COUPON_ISSUE_EXPIRED.status.value()))
@@ -154,6 +193,7 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.code").value(ErrorCode.COUPON_ISSUE_NOT_STARTED.status.value()))
@@ -170,12 +210,14 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 )
             mockMvc
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.code").value(ErrorCode.COUPON_ALREADY_ISSUED.status.value()))
@@ -194,6 +236,7 @@ class UserCouponControllerTest : IntegrationTest() {
                             .perform(
                                 post("/api/v1/users/{userId}/coupons", index + 1)
                                     .contentType(MediaType.APPLICATION_JSON)
+                                    .header(HttpHeaders.AUTHORIZATION, index + 1)
                                     .content(objectMapper.writeValueAsString(request)),
                             ).andReturn()
                     if (httpResponse.response.status != HttpStatus.CREATED.value()) {
@@ -221,16 +264,45 @@ class UserCouponControllerTest : IntegrationTest() {
                 .perform(
                     post("/api/v1/users/{userId}/coupons", userId)
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userId)
                         .content(objectMapper.writeValueAsString(IssueCouponRequest(1L))),
                 )
             mockMvc
                 .perform(
-                    get("/api/v1/users/{userId}/coupons", userId),
+                    get("/api/v1/users/{userId}/coupons", userId)
+                        .header(HttpHeaders.AUTHORIZATION, userId),
                 ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.code").value(SuccessCode.COUPON_LIST_QUERY.status.value()))
                 .andExpect(jsonPath("$.message").value(SuccessCode.COUPON_LIST_QUERY.message))
                 .andExpect(jsonPath("$.data.coupons", Matchers.hasSize<CouponInfo>(1)))
                 .andExpect(jsonPath("$.data.hasNext").value(false))
+        }
+
+        @Test
+        @DisplayName("[실패] 인증 헤더의 사용자 ID가 유효하지 않으면 401 반환")
+        fun test_fail_when_invalid_user_id() {
+            val userId = 1L
+
+            mockMvc
+                .perform(
+                    get("/api/v1/users/{userId}/coupons", userId),
+                ).andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.status.value()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.message))
+        }
+
+        @Test
+        @DisplayName("[실패] 인증 아이디와 사용자 아이디가 다르면 403 반환")
+        fun test_fail_when_user_id_and_auth_id_diff() {
+            val userId = 1L
+
+            mockMvc
+                .perform(
+                    get("/api/v1/users/{userId}/coupons", userId)
+                        .header(HttpHeaders.AUTHORIZATION, 2L),
+                ).andExpect(status().isForbidden)
+                .andExpect(jsonPath("$.code").value(ErrorCode.FORBIDDEN.status.value()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN.message))
         }
 
         @Test
@@ -240,7 +312,8 @@ class UserCouponControllerTest : IntegrationTest() {
 
             mockMvc
                 .perform(
-                    get("/api/v1/users/{userId}/coupons", userId),
+                    get("/api/v1/users/{userId}/coupons", userId)
+                        .header(HttpHeaders.AUTHORIZATION, userId),
                 ).andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.status.value()))
                 .andExpect(jsonPath("$.message").value(ErrorCode.USER_NOT_FOUND.message))

--- a/src/test/kotlin/kr/hhplus/be/server/api/coupon/request/IssueCouponRequestTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/coupon/request/IssueCouponRequestTest.kt
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.api.coupon.request
+
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class IssueCouponRequestTest {
+    @Nested
+    @DisplayName("command 객체 변환")
+    inner class ToCommand {
+        @Test
+        @DisplayName("[실패] 유저 아이디랑 인증 아이디가 다를 때 FORBIDDEN 에러 발생")
+        fun userIdAuthIdDiffTest() {
+            val issueCouponRequest = IssueCouponRequest(1)
+
+            assertThatThrownBy { issueCouponRequest.toCommand(1, 2) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasFieldOrPropertyWithValue("code", ErrorCode.FORBIDDEN)
+        }
+    }
+}

--- a/src/test/kotlin/kr/hhplus/be/server/api/order/request/OrderRequestTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/order/request/OrderRequestTest.kt
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.api.order.request
+
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class OrderRequestTest {
+    @Nested
+    @DisplayName("command 객체 변환")
+    inner class ToCommand {
+        @Test
+        @DisplayName("[실패] 유저 아이디랑 인증 아이디가 다를 때 FORBIDDEN 에러 발생")
+        fun userIdAuthIdDiffTest() {
+            val orderRequest = OrderRequest(1, emptyList(), null)
+
+            assertThatThrownBy { orderRequest.toCommand(2) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasFieldOrPropertyWithValue("code", ErrorCode.FORBIDDEN)
+        }
+    }
+}

--- a/src/test/kotlin/kr/hhplus/be/server/api/payment/request/PaymentRequestTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/payment/request/PaymentRequestTest.kt
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.api.payment.request
+
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PaymentRequestTest {
+    @Nested
+    @DisplayName("command 객체 변환")
+    inner class ToCommand {
+        @Test
+        @DisplayName("[실패] 유저 아이디랑 인증 아이디가 다를 때 FORBIDDEN 에러 발생")
+        fun userIdAuthIdDiffTest() {
+            val paymentRequest = PaymentRequest(1, 1)
+
+            assertThatThrownBy { paymentRequest.toCommand(2) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasFieldOrPropertyWithValue("code", ErrorCode.FORBIDDEN)
+        }
+    }
+}

--- a/src/test/kotlin/kr/hhplus/be/server/api/product/ProductControllerTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/product/ProductControllerTest.kt
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.api.product
 
-import kr.hhplus.be.server.api.product.response.PopularProductResponse
-import kr.hhplus.be.server.api.product.response.ProductResponse
+import kr.hhplus.be.server.application.product.info.PopularProductInfo
+import kr.hhplus.be.server.application.product.info.ProductInfo
 import kr.hhplus.be.server.common.constant.SuccessCode
 import kr.hhplus.be.server.domain.order.OrderStatus
 import kr.hhplus.be.server.infrastructure.persistence.order.JpaOrderItemRepository
@@ -92,7 +92,7 @@ class ProductControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.code").value(SuccessCode.PRODUCT_QUERY.status.value()))
                 .andExpect(jsonPath("$.message").value(SuccessCode.PRODUCT_QUERY.message))
                 .andExpect(jsonPath("$.data.products").isArray)
-                .andExpect(jsonPath("$.data.products", Matchers.hasSize<ProductResponse>(10)))
+                .andExpect(jsonPath("$.data.products", Matchers.hasSize<ProductInfo>(10)))
                 .andExpect(jsonPath("$.data.hasNext").value(true))
         }
 
@@ -108,7 +108,7 @@ class ProductControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.code").value(SuccessCode.PRODUCT_QUERY.status.value()))
                 .andExpect(jsonPath("$.message").value(SuccessCode.PRODUCT_QUERY.message))
                 .andExpect(jsonPath("$.data.products").isArray)
-                .andExpect(jsonPath("$.data.products", Matchers.hasSize<ProductResponse>(1)))
+                .andExpect(jsonPath("$.data.products", Matchers.hasSize<ProductInfo>(1)))
                 .andExpect(jsonPath("$.data.hasNext").value(false))
         }
     }
@@ -125,7 +125,7 @@ class ProductControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.code").value(SuccessCode.POPULAR_PRODUCT_QUERY.status.value()))
                 .andExpect(jsonPath("$.message").value(SuccessCode.POPULAR_PRODUCT_QUERY.message))
                 .andExpect(jsonPath("$.data.products").isArray)
-                .andExpect(jsonPath("$.data.products", Matchers.hasSize<PopularProductResponse>(5)))
+                .andExpect(jsonPath("$.data.products", Matchers.hasSize<PopularProductInfo>(5)))
         }
     }
 }

--- a/src/test/kotlin/kr/hhplus/be/server/api/user/UserBalanceControllerTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/user/UserBalanceControllerTest.kt
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.api.user
 
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.classic.methods.HttpHead
 import kr.hhplus.be.server.api.user.request.UserBalanceRequest
 import kr.hhplus.be.server.common.constant.ErrorCode
 import kr.hhplus.be.server.common.constant.SuccessCode
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -72,6 +74,7 @@ class UserBalanceControllerTest : IntegrationTest() {
             mockMvc
                 .perform(
                     patch("/api/v1/users/{userId}/balance", userId)
+                        .header(HttpHeaders.AUTHORIZATION, "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(
                             objectMapper.writeValueAsString(UserBalanceRequest(amount)),

--- a/src/test/kotlin/kr/hhplus/be/server/api/user/request/UserBalanceRequestTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/api/user/request/UserBalanceRequestTest.kt
@@ -21,4 +21,18 @@ class UserBalanceRequestTest {
                 .hasFieldOrPropertyWithValue("code", ErrorCode.USER_BALANCE_BELOW_MINIMUM)
         }
     }
+
+    @Nested
+    @DisplayName("command 객체 변환")
+    inner class ToCommand {
+        @Test
+        @DisplayName("[실패] 유저 아이디랑 인증 아이디가 다를 때 FORBIDDEN 에러 발생")
+        fun testFailWhenUserIdAndAuthIdDiff() {
+            val userBalanceRequest = UserBalanceRequest(1000)
+
+            assertThatThrownBy { userBalanceRequest.toCommand(1, 2) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasFieldOrPropertyWithValue("code", ErrorCode.FORBIDDEN)
+        }
+    }
 }

--- a/src/test/kotlin/kr/hhplus/be/server/application/coupon/command/FindUserCouponCommandTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/application/coupon/command/FindUserCouponCommandTest.kt
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.application.coupon.command
+
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.Pageable
+
+class FindUserCouponCommandTest {
+    @Nested
+    @DisplayName("command 객체 생성")
+    inner class Of {
+        @Test
+        @DisplayName("[실패] 유저 아이디랑 인증 아이디가 다를 때 FORBIDDEN 에러 발생")
+        fun userIdAuthIdDiffTest() {
+            assertThatThrownBy { FindUserCouponCommand.of(1, 2, Pageable.ofSize(10)) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasFieldOrPropertyWithValue("code", ErrorCode.FORBIDDEN)
+        }
+    }
+}

--- a/src/test/kotlin/kr/hhplus/be/server/application/user/command/GetBalanceCommandTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/application/user/command/GetBalanceCommandTest.kt
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.application.user.command
+
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class GetBalanceCommandTest {
+    @Nested
+    @DisplayName("command 객체 생성")
+    inner class Of {
+        @Test
+        @DisplayName("[실패] 유저 아이디랑 인증 아이디가 다를 때 FORBIDDEN 에러 발생")
+        fun userIdAuthIdDiffTest() {
+            assertThatThrownBy { GetBalanceCommand.of(1, 2) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasFieldOrPropertyWithValue("code", ErrorCode.FORBIDDEN)
+        }
+    }
+}

--- a/src/test/kotlin/kr/hhplus/be/server/common/filter/HttpLoggingFilterTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/common/filter/HttpLoggingFilterTest.kt
@@ -1,0 +1,89 @@
+package kr.hhplus.be.server.common.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HttpLoggingFilterTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Nested
+    @DisplayName("HTTP 요청 / 응답 로깅 필터")
+    inner class DoFilterInternal {
+        @Test
+        @DisplayName("[성공] HTTP 요청 / 응답시 로깅을 수행한다.")
+        fun successTest() {
+            val wantRequestLog =
+                "HTTP Request: [Method: POST, URI: /test/log, Headers: Content-Type: application/json;charset=UTF-8, Content-Length: 15, Body: {\"key\":\"value\"}]"
+            val wantResponseLog = "HTTP Response: [Status: 200, Body: Request received: {key=value}]"
+            val outputStream = ByteArrayOutputStream()
+            System.setOut(PrintStream(outputStream))
+            mockMvc
+                .perform(
+                    post("/test/log")
+                        .contentType("application/json")
+                        .content("""{"key":"value"}"""),
+                )
+
+            val logOutput = outputStream.toString()
+
+            assertThat(logOutput).contains(wantRequestLog)
+            assertThat(logOutput).contains(wantResponseLog)
+        }
+
+        @Test
+        @DisplayName("[성공] 본문에 요청 / 응답이 없는 경우 No Body 라는 문자열로 대체된다.")
+        fun successNoBodyTest() {
+            val wantRequestLog =
+                "HTTP Request: [Method: POST, URI: /test/log/nobody, Headers: Content-Type: application/json;charset=UTF-8, Body: No Body]"
+            val wantResponseLog = "HTTP Response: [Status: 200, Body: No Body]"
+            val outputStream = ByteArrayOutputStream()
+            System.setOut(PrintStream(outputStream))
+            mockMvc
+                .perform(
+                    post("/test/log/nobody")
+                        .contentType("application/json"),
+                )
+
+            val logOutput = outputStream.toString()
+
+            assertThat(logOutput).contains(wantRequestLog)
+            assertThat(logOutput).contains(wantResponseLog)
+        }
+    }
+}
+
+@RestController
+@RequestMapping("/test")
+@ActiveProfiles("test")
+class TestLogController {
+    @PostMapping("/log")
+    fun handleRequest(
+        @RequestBody body: Map<String, Any>,
+    ): ResponseEntity<String> = ResponseEntity.ok("Request received: $body")
+}
+
+@RestController
+@RequestMapping("/test")
+@ActiveProfiles("test")
+class TestLogNobodyController {
+    @PostMapping("/log/nobody")
+    fun handleRequest(): ResponseEntity<String> = ResponseEntity.ok().build()
+}

--- a/src/test/kotlin/kr/hhplus/be/server/common/interceptor/UserAuthenticationInterceptorTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/common/interceptor/UserAuthenticationInterceptorTest.kt
@@ -1,0 +1,54 @@
+package kr.hhplus.be.server.common.interceptor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kr.hhplus.be.server.common.constant.AuthConstants
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class UserAuthenticationInterceptorTest {
+    private val objectMapper: ObjectMapper = ObjectMapper()
+    private val userAuthenticationInterceptor: UserAuthenticationInterceptor =
+        UserAuthenticationInterceptor(objectMapper)
+
+    @Nested
+    @DisplayName("요청 전 사용자 핸들링")
+    inner class PreHandle {
+        @Test
+        @DisplayName("[성공] 사용자 ID가 숫자로 구성되어 있으면 true 반환")
+        fun test() {
+            val userId = 1L
+
+            val request =
+                MockHttpServletRequest()
+                    .apply { addHeader(HttpHeaders.AUTHORIZATION, userId.toString()) }
+            val response = MockHttpServletResponse()
+
+            val got = userAuthenticationInterceptor.preHandle(request, response, Any())
+
+            assertThat(got).isTrue()
+            val attribute = request.getAttribute(AuthConstants.AUTH_ID)
+            assertThat(attribute).isEqualTo(userId.toString())
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", " ", "a", "1a"])
+        @DisplayName("[실패] 숫자로 구성된 아이디가 아닌 경우 false 반환")
+        fun testFail(userId: String) {
+            val request =
+                MockHttpServletRequest()
+                    .apply { addHeader(HttpHeaders.AUTHORIZATION, userId) }
+            val response = MockHttpServletResponse()
+
+            val got = userAuthenticationInterceptor.preHandle(request, response, Any())
+
+            assertThat(got).isFalse()
+        }
+    }
+}


### PR DESCRIPTION
## PR 설명
- [✨ feat : 필터를 이용하여 HTTP 요청 / 응답에 대해 로그를 남기는 설정 추가](https://github.com/zxcv9203/ecommerce/pull/9/commits/6fe669d2c685b13f9af1b7210f873a765ad49cd1)
  - 필터를 이용하여 HTTP Request와 Response에 대한 로깅을 기록하는 기능을 구현했습니다.
  - 통합 테스트를 통해 실제 내가 원하는 로깅이 되었는지 확인하는 테스트를 작성했습니다. 
- [♻️ refactor : HTTP 응답 객체는 표현계층에서 변경하도록 수정](https://github.com/zxcv9203/ecommerce/pull/9/commits/ffa34e4409abb626f45c5da6ba228e3e16fb7407)
  - 기존에는 Application or Domain 계층에서 바로 Response를 반환하도록 작성이 되어있었는데 해당 부분이 의존성이 역전되는 문제가 있어 Info라는 DTO를 Controller에 반환하고 Controller에서 Response로 변환하게끔 변경했습니다. 
- [✨ feat : Authorization 헤더에 사용자 ID를 입력 받아 유효한 ID인지 체크하는 인터셉터 구현](https://github.com/zxcv9203/ecommerce/pull/9/commits/33c02c4075b397596b6a642db67f05910e164d6e)
  - Authorization 헤더에 사용자 ID를 입력받아 유효한 형식인지 체크하는 인터셉터 추가
  - 인증받은 사용자 ID와 URL Path에 명시된 사용자 ID or Body에 명시된 사용자 ID가 일치하는지 확인하는 검증 로직 추가   
  - 인증을 진행하는 API에 대해 정상 동작하는지 체크하는 통합 테스트 추가 (API 레벨)

## 리뷰 포인트
- 필터를 이용해서 HTTP 요청 / 응답을 작성할때 현재 작성한 정보말고도 추가로 찍으면 좋을 만한 정보가 있을지 궁금합니다. https://github.com/zxcv9203/ecommerce/pull/9#discussion_r1918852150

- 현재 인터셉터에서 사용자 ID를 입력 받아 유효한지 체크하는 로직을 작성했는데 이때 인증받은 사용자 ID와 URL Path에 명시된 사용자 ID or Body에 명시된 사용자 ID가 일치하는지 확인하는 검증 로직을 체크하는 과정에서 해당 책임을 DTO에게 주었는데 이러다보니 모든 DTO에 중복 로직이 발생하는 것 같습니다. https://github.com/zxcv9203/ecommerce/pull/9#discussion_r1918848955 
  - 이런 부분을 해소하기 위해 사용자는 헤더의 사용자를 사용하도록 리팩토링하는게 좋다는 생각이 들었는데 이에 대한 코치님의 의견이 궁금합니다. 

## Definition of Done (DoD)
- [x] 필터를 이용해서 HTTP 요청 / 응답이 정상적으로 로깅되는지 확인
- [x] 하위 계층에서 HTTP 응답 객체를 생성하지 않고 표현 계층(Controller)에서 HTTP 응답 객체를 생성하도록 변경
- [x] Authorization 헤더에 사용자 ID를 입력받아 유효한 형식인지 체크하는 인터셉터 추가
- [x] 인증받은 사용자 ID와 URL Path에 명시된 사용자 ID or Body에 명시된 사용자 ID가 일치하는지 확인하는 검증 로직 추가   