### PR TITLE
[STEP-12] 동시성 제어 로직 개선 및 동시성 테스트 코드 추가 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ group = "kr.hhplus.be"
 version = getGitHash()
 val swaggerVersion = "2.7.0"
 val mockkVersion = "1.13.14"
+val redissonVersion = "3.43.0"
 
 java {
     toolchain {
@@ -55,6 +56,8 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$swaggerVersion")
     // DB
     runtimeOnly("com.mysql:mysql-connector-j")
+
+    implementation("org.redisson:redisson-spring-boot-starter:$redissonVersion")
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
-
+  redis:
+    image: redis:7.4.2
+    ports:
+      - "6379:6379"
 networks:
   default:
     driver: bridge

--- a/src/main/kotlin/kr/hhplus/be/server/application/coupon/CouponUseCase.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/coupon/CouponUseCase.kt
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.application.coupon.command.FindUserCouponCommand
 import kr.hhplus.be.server.application.coupon.command.IssueCouponCommand
 import kr.hhplus.be.server.application.coupon.info.CouponsInfo
 import kr.hhplus.be.server.domain.coupon.CouponService
+import kr.hhplus.be.server.domain.lock.LockManager
 import kr.hhplus.be.server.domain.user.UserService
 import org.springframework.stereotype.Component
 
@@ -11,10 +12,13 @@ import org.springframework.stereotype.Component
 class CouponUseCase(
     private val couponService: CouponService,
     private val userService: UserService,
+    private val lockManager: LockManager,
 ) {
     fun issue(command: IssueCouponCommand) {
         val user = userService.getById(command.userId)
-        couponService.issue(user, command.couponPolicyId)
+        lockManager.withLock("coupon:${command.couponPolicyId}") {
+            couponService.issue(user, command.couponPolicyId)
+        }
     }
 
     fun findAllByUserId(command: FindUserCouponCommand): CouponsInfo {

--- a/src/main/kotlin/kr/hhplus/be/server/common/constant/ErrorCode.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/common/constant/ErrorCode.kt
@@ -28,6 +28,7 @@ enum class ErrorCode(
     ORDER_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 주문입니다."),
     USER_BALANCE_USE_FAILED(HttpStatus.BAD_REQUEST, "잔액 사용에 실패했습니다."),
     INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "잔액이 부족합니다."),
+    LOCK_TIMEOUT(HttpStatus.BAD_REQUEST, "잠금 시간이 초과되었습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponPolicy.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponPolicy.kt
@@ -36,6 +36,10 @@ class CouponPolicy(
     @Column(name = "discount_amount", nullable = false)
     @Comment("할인 금액")
     val discountAmount: Long,
+    @Version
+    @Column(name = "version", nullable = false)
+    @Comment("낙관적락을 위한 버전")
+    val version: Long = 0,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,

--- a/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponPolicyRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponPolicyRepository.kt
@@ -1,5 +1,5 @@
 package kr.hhplus.be.server.domain.coupon
 
 interface CouponPolicyRepository {
-    fun findByIdWithLock(id: Long): CouponPolicy?
+    fun findById(id: Long): CouponPolicy?
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/coupon/CouponService.kt
@@ -22,7 +22,7 @@ class CouponService(
         couponPolicyId: Long,
     ) {
         val couponPolicy =
-            couponPolicyRepository.findByIdWithLock(couponPolicyId)
+            couponPolicyRepository.findById(couponPolicyId)
                 ?: throw BusinessException(ErrorCode.COUPON_NOT_FOUND)
         couponRepository
             .findByUserIdAndPolicyId(user.id, couponPolicyId)

--- a/src/main/kotlin/kr/hhplus/be/server/domain/lock/LockManager.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/lock/LockManager.kt
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.domain.lock
+
+interface LockManager {
+    fun <T> withLock(
+        key: String,
+        block: () -> T,
+    ): T
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/RedissonLockManager.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/RedissonLockManager.kt
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.infrastructure.lock
+
+import kr.hhplus.be.server.common.constant.ErrorCode
+import kr.hhplus.be.server.common.exception.BusinessException
+import kr.hhplus.be.server.domain.lock.LockManager
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RedissonLockManager(
+    private val redissonClient: RedissonClient,
+) : LockManager {
+    override fun <T> withLock(
+        key: String,
+        block: () -> T,
+    ): T {
+        val lock = redissonClient.getLock(key)
+        return if (lock.tryLock(5, 10, TimeUnit.SECONDS)) {
+            try {
+                block()
+            } finally {
+                lock.unlock()
+            }
+        } else {
+            throw BusinessException(ErrorCode.LOCK_TIMEOUT)
+        }
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/DataJpaCouponPolicyRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/DataJpaCouponPolicyRepository.kt
@@ -1,13 +1,6 @@
 package kr.hhplus.be.server.infrastructure.persistence.coupon
 
-import jakarta.persistence.LockModeType
 import kr.hhplus.be.server.domain.coupon.CouponPolicy
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
-import org.springframework.data.jpa.repository.Query
 
-interface DataJpaCouponPolicyRepository : JpaRepository<CouponPolicy, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT cp FROM CouponPolicy cp WHERE cp.id = :id")
-    fun findByIdWithLock(id: Long): CouponPolicy?
-}
+interface DataJpaCouponPolicyRepository : JpaRepository<CouponPolicy, Long>

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/JpaCouponPolicyRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/coupon/JpaCouponPolicyRepository.kt
@@ -2,11 +2,12 @@ package kr.hhplus.be.server.infrastructure.persistence.coupon
 
 import kr.hhplus.be.server.domain.coupon.CouponPolicy
 import kr.hhplus.be.server.domain.coupon.CouponPolicyRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
 class JpaCouponPolicyRepository(
     private val dataJpaCouponPolicyRepository: DataJpaCouponPolicyRepository,
 ) : CouponPolicyRepository {
-    override fun findByIdWithLock(id: Long): CouponPolicy? = dataJpaCouponPolicyRepository.findByIdWithLock(id)
+    override fun findById(id: Long): CouponPolicy? = dataJpaCouponPolicyRepository.findByIdOrNull(id)
 }

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS coupon_policies
     end_time        DATETIME     NOT NULL COMMENT '종료 시간',
     discount_type   VARCHAR(20)  NOT NULL COMMENT '할인 유형',
     discount_amount BIGINT       NOT NULL COMMENT '할인 금액',
+    version         BIGINT       NOT NULL DEFAULT 0 COMMENT '낙관적락을 위한 버전',
     created_at      DATETIME     NOT NULL COMMENT '생성 시간',
     updated_at      DATETIME     NOT NULL COMMENT '수정 시간'
 );

--- a/src/test/kotlin/kr/hhplus/be/server/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/TestcontainersConfiguration.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server
 
 import jakarta.annotation.PreDestroy
 import org.springframework.context.annotation.Configuration
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.utility.DockerImageName
 
@@ -10,21 +11,35 @@ class TestcontainersConfiguration {
     @PreDestroy
     fun preDestroy() {
         if (mySqlContainer.isRunning) mySqlContainer.stop()
+        if (redisContainer.isRunning) redisContainer.stop()
     }
 
     companion object {
-        val mySqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.0"))
-            .withDatabaseName("hhplus")
-            .withUsername("test")
-            .withPassword("test")
-            .apply {
-                start()
-            }
+        val mySqlContainer: MySQLContainer<*> =
+            MySQLContainer(DockerImageName.parse("mysql:8.0"))
+                .withDatabaseName("hhplus")
+                .withUsername("test")
+                .withPassword("test")
+                .apply {
+                    start()
+                }
+        val redisContainer: GenericContainer<*> =
+            GenericContainer<Nothing>(DockerImageName.parse("redis:7.4.2"))
+                .apply {
+                    withExposedPorts(6379)
+                    start()
+                }
 
         init {
-            System.setProperty("spring.datasource.url", mySqlContainer.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC")
+            System.setProperty(
+                "spring.datasource.url",
+                mySqlContainer.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC",
+            )
             System.setProperty("spring.datasource.username", mySqlContainer.username)
             System.setProperty("spring.datasource.password", mySqlContainer.password)
+            System.setProperty("spring.datasource.hikari.maximum-pool-size", "3")
+            System.setProperty("spring.datasource.hikari.connection-timeout", "10000")
+            System.setProperty("spring.datasource.hikari.max-lifetime", "60000")
         }
     }
 }

--- a/src/test/kotlin/kr/hhplus/be/server/application/coupon/IntegrationCouponUseCaseTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/application/coupon/IntegrationCouponUseCaseTest.kt
@@ -1,0 +1,62 @@
+package kr.hhplus.be.server.application.coupon
+
+import kr.hhplus.be.server.application.coupon.command.IssueCouponCommand
+import kr.hhplus.be.server.helper.ConcurrentTestHelper
+import kr.hhplus.be.server.infrastructure.persistence.coupon.DataJpaCouponPolicyRepository
+import kr.hhplus.be.server.infrastructure.persistence.coupon.DataJpaCouponRepository
+import kr.hhplus.be.server.infrastructure.persistence.user.DataJpaUserRepository
+import kr.hhplus.be.server.stub.CouponFixture
+import kr.hhplus.be.server.stub.UserFixture
+import kr.hhplus.be.server.template.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class IntegrationCouponUseCaseTest : IntegrationTest() {
+    @Autowired
+    private lateinit var couponUseCase: CouponUseCase
+
+    @Autowired
+    private lateinit var dataJpaUserRepository: DataJpaUserRepository
+
+    @Autowired
+    private lateinit var dataJpaCouponPolicyRepository: DataJpaCouponPolicyRepository
+
+    @Autowired
+    private lateinit var dataJpaCouponRepository: DataJpaCouponRepository
+
+    @BeforeEach
+    fun setUp() {
+        val users = (1..15L).map { UserFixture.create(id = 0L, name = "user $it") }
+        dataJpaUserRepository.saveAllAndFlush(users)
+
+        val couponPolicy = CouponFixture.createPolicy(id = 0L, totalCount = 10, currentCount = 0)
+        dataJpaCouponPolicyRepository.saveAndFlush(couponPolicy)
+    }
+
+    @Nested
+    @DisplayName("쿠폰 발급 동시성 테스트")
+    inner class IssueCouponConcurrencyTest {
+        @Test
+        @DisplayName("[동시성] 동시에 15명의 사용자가 쿠폰을 발급할 때 10번 성공하고 5번 실패해야 한다.")
+        fun issueCouponConcurrencyTest() {
+            val couponPolicyId = 1L
+
+            val result =
+                ConcurrentTestHelper.executeAsyncTasksWithIndex(15) {
+                    couponUseCase.issue(IssueCouponCommand(it.toLong() + 1, couponPolicyId))
+                }
+
+            val successCount = result.count { it }
+            val failCount = result.count { !it }
+            val issuedCoupons = dataJpaCouponRepository.findAll()
+
+            assertThat(successCount).isEqualTo(10)
+            assertThat(failCount).isEqualTo(5)
+            assertThat(issuedCoupons.size).isEqualTo(successCount)
+        }
+    }
+}

--- a/src/test/kotlin/kr/hhplus/be/server/domain/coupon/CouponServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/coupon/CouponServiceTest.kt
@@ -36,7 +36,7 @@ class CouponServiceTest {
             val user = UserFixture.create()
             val couponPolicyId = 1L
 
-            every { couponPolicyRepository.findByIdWithLock(couponPolicyId) } returns null
+            every { couponPolicyRepository.findById(couponPolicyId) } returns null
 
             assertThatThrownBy { couponService.issue(user, couponPolicyId) }
                 .isInstanceOf(BusinessException::class.java)

--- a/src/test/kotlin/kr/hhplus/be/server/domain/coupon/IntegrationCouponServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/coupon/IntegrationCouponServiceTest.kt
@@ -1,19 +1,18 @@
 package kr.hhplus.be.server.domain.coupon
 
+import kr.hhplus.be.server.domain.order.Order
 import kr.hhplus.be.server.helper.ConcurrentTestHelper
 import kr.hhplus.be.server.infrastructure.persistence.coupon.DataJpaCouponPolicyRepository
 import kr.hhplus.be.server.infrastructure.persistence.coupon.DataJpaCouponRepository
+import kr.hhplus.be.server.infrastructure.persistence.order.DataJpaOrderRepository
 import kr.hhplus.be.server.infrastructure.persistence.user.DataJpaUserRepository
 import kr.hhplus.be.server.stub.CouponFixture
+import kr.hhplus.be.server.stub.OrderFixture
 import kr.hhplus.be.server.stub.UserFixture
 import kr.hhplus.be.server.template.IntegrationTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.repository.findByIdOrNull
 
 class IntegrationCouponServiceTest : IntegrationTest() {
     @Autowired
@@ -28,36 +27,44 @@ class IntegrationCouponServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var dataJpaCouponRepository: DataJpaCouponRepository
 
+    @Autowired
+    private lateinit var dataJpaOrderRepository: DataJpaOrderRepository
+
+    private lateinit var coupon: Coupon
+
+    private lateinit var order: Order
+
     @BeforeEach
     fun setUp() {
-        val users = (1..11L).map { UserFixture.create(id = 0L, name = "user $it") }
-        dataJpaUserRepository.saveAllAndFlush(users)
+        val user = UserFixture.create(id = 0L, name = "user")
+        dataJpaUserRepository.saveAndFlush(user)
 
         val couponPolicy = CouponFixture.createPolicy(id = 0L, totalCount = 10, currentCount = 0)
         dataJpaCouponPolicyRepository.saveAndFlush(couponPolicy)
+
+        coupon = CouponFixture.create(id = 0L, policy = couponPolicy)
+        dataJpaCouponRepository.saveAndFlush(coupon)
+
+        order = OrderFixture.create(id = 0L, user = user)
+        dataJpaOrderRepository.saveAndFlush(order)
     }
 
     @Nested
-    @DisplayName("쿠폰 발급 동시성 테스트")
-    inner class IssueCouponConcurrencyTest {
+    @DisplayName("쿠폰 예약 동시성 테스트")
+    inner class Reserve {
         @Test
-        @DisplayName("[동시성] 동시에 11명의 사용자가 쿠폰을 발급할 때 10번 성공하고 1번 실패해야 한다.")
-        fun issueCouponConcurrencyTest() {
-            val couponPolicyId = 1L
-
+        @DisplayName("[동시성] 같은 사용자가 5번 주문 건에 대해 쿠폰 예약을 시도할 때 1번만 성공하고 4번 실패한다.")
+        fun reserveCouponConcurrencyTest() {
             val result =
-                ConcurrentTestHelper.executeAsyncTasksWithIndex(11) {
-                    val user = dataJpaUserRepository.findByIdOrNull(it.toLong() + 1)
-                    couponService.issue(user!!, couponPolicyId)
+                ConcurrentTestHelper.executeAsyncTasksWithIndex(5) {
+                    couponService.reserve(coupon = coupon, order = order)
                 }
 
             val successCount = result.count { it }
-            val failCount = result.count { !it }
-            val issuedCoupons = dataJpaCouponRepository.findAll()
+            val failedCount = result.count { !it }
 
-            assertThat(successCount).isEqualTo(10)
-            assertThat(failCount).isEqualTo(1)
-            assertThat(issuedCoupons.size).isEqualTo(successCount)
+            assertThat(successCount).isEqualTo(1)
+            assertThat(failedCount).isEqualTo(4)
         }
     }
 }

--- a/src/test/kotlin/kr/hhplus/be/server/domain/product/IntegrationProductServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/product/IntegrationProductServiceTest.kt
@@ -1,0 +1,52 @@
+package kr.hhplus.be.server.domain.product
+
+import kr.hhplus.be.server.application.order.command.OrderItemCommand
+import kr.hhplus.be.server.helper.ConcurrentTestHelper
+import kr.hhplus.be.server.infrastructure.persistence.product.DataJpaProductRepository
+import kr.hhplus.be.server.stub.ProductFixture
+import kr.hhplus.be.server.template.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class IntegrationProductServiceTest : IntegrationTest() {
+    @Autowired
+    private lateinit var productService: ProductService
+
+    @Autowired
+    private lateinit var dataJpaProductRepository: DataJpaProductRepository
+
+    @BeforeEach
+    fun setUp() {
+        val products = (1..10L).map { ProductFixture.create(id = 0L, stock = 10) }
+        dataJpaProductRepository.saveAllAndFlush(products)
+    }
+
+    @Nested
+    @DisplayName("재고 감소 동시성 테스트")
+    inner class ReduceStock {
+        @Test
+        @DisplayName("[동시성] 상품의 재고를 1개씩 11번 감소시킬때 10번 성공하고 1번 실패해야 한다.")
+        fun reduceStockConcurrentTest() {
+            val ids =
+                (1..10L)
+                    .map { OrderItemCommand(it, 1) }
+                    .toList()
+            val result =
+                ConcurrentTestHelper.executeAsyncTasksWithIndex(11) {
+                    productService.reduceStock(ids)
+                }
+
+            val successCount = result.count { it }
+            val failCount = result.count { !it }
+            val updatedProducts = dataJpaProductRepository.findAll()
+
+            assertThat(successCount).isEqualTo(10)
+            assertThat(failCount).isEqualTo(1)
+            assertThat(updatedProducts.all { it.stock == 0 }).isTrue()
+        }
+    }
+}


### PR DESCRIPTION
## PR 설명
- [🔧 config : 레디스로 분산락 구현을 위한 테스트 컨테이너 추가 및 라이브러리 추가](https://github.com/zxcv9203/ecommerce/pull/15/commits/5802c55fc0b34f11df0bc9f8b83aa06404253634)
  - 레디스 관련 설정(테스트 컨테이너, 도커 컴포즈, Redisson 라이브러리)을 추가했습니다.
- [♻️ refactor : 선착순 쿠폰 발급시 분산락을 사용하여 동시성 제어하도록 변경](https://github.com/zxcv9203/ecommerce/pull/15/commits/e0f1223ff369e88fba948c2d7e2534b49d841113)
  - 선착순 쿠폰의 경우 발급받을때 가장 트래픽이 증가할 수 있는 항목이라 생각하여 부하를 줄이기 위해 분산락을 적용했습니다.
- [✅ test : 주문시 쿠폰 예약에 대한 동시성 테스트 추가](https://github.com/zxcv9203/ecommerce/pull/15/commits/a52bb4d658f874a56e2aea4b393b1b679300ed4d)
  - 쿠폰 예약에 대한 테스트만 진행하기 위해 쿠폰 예약에 대한 서비스 레이어의 동시성 테스트를 추가했습니다.
-  [✅ test : 재고감소에 대한 동시성 테스트 추가](https://github.com/zxcv9203/ecommerce/pull/15/commits/ce6d50018a743e744b2a1c8936c50fdc970f0bd9)
   - 재고감소에 대한 테스트만 진행하기 위해 서비스 레이어의 동시성 테스트를 추가했습니다. 
- [결제 API 및 E2E 테스트 (통시성 테스트 포함)](https://github.com/zxcv9203/ecommerce/commit/54f4088d513a35949d586cd1f96d709cd134203b)
  - 주문 여러건을 동시에 결제했을때 한번만 성공하는 테스트는 기존의 테스트를 사용했습니다.
- [✅ test : 포인트 충전 / 사용 동시성 테스트 작성](https://github.com/zxcv9203/ecommerce/pull/10/commits/ff42c8a247f8d3ec932eb6388280bc8e317182c9)  
  - 포인트 충전 / 사용 동시성 테스트는 기존에 작성했던 충전 / 사용이 동시에 일어났을때에 대한 테스트를 사용했습니다.
## 리뷰 포인트
- 현재 레디스가 단일 장애 지점이 될 수 있는데 이럴 때 Resilience4j 같은 라이브러리를 사용해서 서킷브레이커를 구현하는게 좋을지 궁금합니다.
- 현재 추가한 통합 테스트 코드들의 비교조건들이 충분한지 궁금합니다. 더 추가로 검증하면 좋을만한 부분이 있는지 궁금합니다. 

## Definition of Done (DoD)
- [x] 분산락 구현을 위한 설정 추가 (테스트 컨테이너, 도커 컴포즈, Redisson 라이브러리)
- [x] 선착순 쿠폰 발급시 분산락을 사용하도록 변경
- [x] 주문시 쿠폰 예약에 대한 동시성 테스트 추가
- [x] 재고감소에 대한 동시성 테스트 추가   